### PR TITLE
Support installing Pressbooks with github-updater.

### DIFF
--- a/pressbooks.php
+++ b/pressbooks.php
@@ -2,6 +2,8 @@
 /*
 Plugin Name: Pressbooks
 Plugin URI: https://pressbooks.org
+GitHub Plugin URI: pressbooks/pressbooks
+Release Asset: true
 Description: Simple Book Production
 Version: 5.9.1-dev
 Author: Pressbooks (Book Oven Inc.)


### PR DESCRIPTION
Add meta-data telling github-updater the repository of Pressbooks. We force the use of releases, as Pressbooks doesn't support installing from git without the added dependancies.